### PR TITLE
Fix `all()` type definition

### DIFF
--- a/src/ProgressPromise.ts
+++ b/src/ProgressPromise.ts
@@ -93,8 +93,8 @@ export class ProgressPromise<T, P extends any = undefined> implements PromiseLik
                 ? T3 | PromiseLike<T3> | ProgressPromise<T3>
                 : ProgressPromise<T3, P3 | undefined>,
             P4 extends undefined
-                ? T4 | PromiseLike<T1> | ProgressPromise<T1>
-                : ProgressPromise<T1, P1 | undefined>,
+                ? T4 | PromiseLike<T4> | ProgressPromise<T4>
+                : ProgressPromise<T4, P4 | undefined>,
         ],
     ): ProgressPromise<[T1, T2, T3, T4], [P1, P2, P3, P4]>;
 


### PR DESCRIPTION
Ran into a type definition error caused by a copy-paste mistake in https://github.com/prezly/progress-promise/commit/e091718a854be0dc1eecd8773ae0318c10382a34